### PR TITLE
Refactor visualization into module and add angle guides

### DIFF
--- a/src/lib/visualization.py
+++ b/src/lib/visualization.py
@@ -1,0 +1,98 @@
+"""Utility functions for visualizing fusion simulation geometry."""
+
+from __future__ import annotations
+import numpy as np
+import pyvista as pv
+
+from src.lib.config import Filepaths
+
+PATH_PLASMA_SURFACE = Filepaths.ROOT + "/" + Filepaths.OUTPUT_DIR + "/" + Filepaths.REACTOR_POLYGONIAL_MESH
+
+
+def add_cylindrical_angle_guides(plotter: pv.Plotter, radius: float, n_angles: int = 8) -> None:
+    """Add radial lines and labels indicating cylindrical coordinate angles.
+
+    Parameters
+    ----------
+    plotter:
+        Active :class:`pyvista.Plotter` instance.
+    radius:
+        Length of each radial line.
+    n_angles:
+        Number of angle markers (default eight, every 45 degrees).
+    """
+
+    angles = np.linspace(0, 2 * np.pi, n_angles, endpoint=False)
+    for angle in angles:
+        start = (0.0, 0.0, 0.0)
+        end = (radius * np.cos(angle), radius * np.sin(angle), 0.0)
+        plotter.add_mesh(pv.Line(start, end), color="white", line_width=1)
+        label_position = (1.1 * end[0], 1.1 * end[1], 0.0)
+        plotter.add_point_labels(
+            [label_position],
+            [f"{np.degrees(angle):.0f}°"],
+            text_color="white",
+            font_size=10,
+            point_size=0,
+        )
+
+
+def render_fusion_plasma(
+    ply_file_path: str = PATH_PLASMA_SURFACE,
+    show_cylindrical_angles: bool = False,
+) -> None:
+    """Load and render a fusion plasma surface from a ``.ply`` file.
+
+    Parameters
+    ----------
+    ply_file_path:
+        Path to the PLY file containing the plasma mesh.
+    show_cylindrical_angles:
+        If ``True`` display angle guides for cylindrical coordinates.
+    """
+
+    # Load the plasma mesh
+    mesh = pv.read(ply_file_path)
+
+    # Create a plotter
+    plotter = pv.Plotter(window_size=(1024, 768))
+    plotter.set_background(color="black")
+
+    # Compute normals for smooth shading
+    mesh.compute_normals(inplace=True)
+
+    # Choose an appealing color map
+    cmap = "plasma"
+
+    # Add mesh to plotter
+    plotter.add_mesh(
+        mesh,
+        color=None,
+        scalars=mesh.points[:, 2],
+        cmap=cmap,
+        smooth_shading=True,
+        opacity=0.9,
+        show_edges=False,
+        lighting=True,
+        specular=0.4,
+        specular_power=15,
+        name="plasma",
+    )
+
+    # Add light for dramatic effect
+    light = pv.Light(position=(1, 1, 1), focal_point=(0, 0, 0), color="white", intensity=0.9)
+    plotter.add_light(light)
+
+    # Set camera view
+    plotter.camera_position = "iso"
+
+    # Add axes and bounds
+    plotter.add_axes(line_width=2)
+    plotter.show_bounds(color="white")
+
+    if show_cylindrical_angles:
+        radius = np.max(np.linalg.norm(mesh.points[:, :2], axis=1))
+        add_cylindrical_angle_guides(plotter, radius)
+
+    # Render the visualization
+    plotter.show(title="Fusion Plasma Surface")

--- a/src/render-fusion-simulation.py
+++ b/src/render-fusion-simulation.py
@@ -1,63 +1,16 @@
-"""Visualization of Fusion Plasma Surface using PyVista"""
+"""Command-line interface for rendering fusion plasma visualizations."""
 
-import pyvista as pv
+import argparse
 
-from src.lib.config import Filepaths
-
-PATH_PLASMA_SURFACE = (
-    Filepaths.ROOT + "/" + Filepaths.OUTPUT_DIR + "/" + Filepaths.REACTOR_POLYGONIAL_MESH
-)
-
-
-def render_fusion_plasma(ply_file_path: str=PATH_PLASMA_SURFACE) -> None:
-    """
-    Load and render a fusion plasma surface from a .ply file using PyVista.
-
-    Parameters:
-        ply_file_path (str): Path to the PLY file containing the plasma mesh.
-    """
-    # Load the plasma mesh
-    mesh = pv.read(ply_file_path)
-
-    # Create a plotter
-    plotter = pv.Plotter(window_size=(1024, 768))
-    plotter.set_background(color="black")
-
-    # Compute normals for smooth shading
-    mesh.compute_normals(inplace=True)
-
-    # Choose an appealing color map
-    cmap = "plasma"
-
-    # Add mesh to plotter
-    plotter.add_mesh(
-        mesh,
-        color=None,
-        scalars=mesh.points[:, 2],  # Use Z-axis position for coloring
-        cmap=cmap,
-        smooth_shading=True,
-        opacity=0.9,
-        show_edges=False,
-        lighting=True,
-        specular=0.4,
-        specular_power=15,
-        name="plasma",
-    )
-
-    # Add light for dramatic effect
-    light = pv.Light(position=(1, 1, 1), focal_point=(0, 0, 0), color="white", intensity=0.9)
-    plotter.add_light(light)
-
-    # Set camera view
-    plotter.camera_position = "iso"
-
-    # Add axes and bounds
-    plotter.add_axes(line_width=2)
-    plotter.show_bounds(color="white")
-
-    # Render the visualization
-    plotter.show(title="Fusion Plasma Surface")
-
+from src.lib.visualization import render_fusion_plasma
 
 if __name__ == "__main__":
-    render_fusion_plasma()
+    parser = argparse.ArgumentParser(description="Render fusion plasma surface.")
+    parser.add_argument(
+        "--show-angles",
+        action="store_true",
+        help="Display cylindrical coordinate angles in the plot.",
+    )
+    args = parser.parse_args()
+
+    render_fusion_plasma(show_cylindrical_angles=args.show_angles)


### PR DESCRIPTION
## Summary
- modularize plasma rendering into dedicated `visualization` module
- add optional cylindrical angle guides for plots
- expose `--show-angles` CLI flag

## Testing
- `ruff format src/lib/visualization.py src/render-fusion-simulation.py`
- `ruff check src/lib/visualization.py src/render-fusion-simulation.py`
- `pytest`
- `python -m py_compile src/lib/visualization.py src/render-fusion-simulation.py`
- `pip install numpy pyvista` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fae4508508331aba9cbd4f486ffdb