### PR TITLE
Implement segmented toroidal coil visualization

### DIFF
--- a/src/reactor_geometry.py
+++ b/src/reactor_geometry.py
@@ -121,11 +121,10 @@ def generate_toroidal_coils_3d(
     toroidal_coil_2d: ToroidalCoil2D,
     toroid_coil_config: ToroidalCoilConfig,
 ) -> list[ToroidalCoil3D]:
-    """
-    Generate full 3D geometry for toroidal coils from 2D cross-section using efficient numpy operations.
-    """
+    """Generate full 3D geometry for toroidal coils from 2D cross-section using efficient numpy operations."""
+
     phi_angles = np.linspace(0, 2 * np.pi, toroid_coil_config.n_field_coils, endpoint=False)
-    coils = []
+    coils: list[ToroidalCoil3D] = []
 
     # Prepare 2D cross-section
     r_inner_2d = toroidal_coil_2d.R_inner
@@ -203,7 +202,9 @@ if __name__ == "__main__":
     plasma_boundary, toroidal_coil_2d = calculate_2d_geometry(plasma_config=plasma_config, toroid_coil_config=toroid_coil_config)
 
     fusion_plasma = generate_fusion_plasma(plasma_boundary=plasma_boundary)
-    toroidal_coils_3d = generate_toroidal_coils_3d(toroidal_coil_2d=toroidal_coil_2d, toroid_coil_config=toroid_coil_config)
+    toroidal_coils_3d = generate_toroidal_coils_3d(
+        toroidal_coil_2d=toroidal_coil_2d, toroid_coil_config=toroid_coil_config
+    )
 
     plotter = initialize_plotter(shape=(1, 2))
 


### PR DESCRIPTION
## Summary
- Restore unsegmented `generate_toroidal_coils_3d` so coils retain their full geometry
- Slice coil point clouds into blocks during visualization and render each block with alternating colors and labels
- Clean up unused cylindrical angle code

## Testing
- `ruff check --fix src/reactor_geometry.py src/lib/visualization.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68923e28f8f88331b0f7ca5958c754b7